### PR TITLE
[FCP-4780] Add ProdEng to container labels and codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
 * @getflywheel/platform
+* @getflywheel/hosting-operations
+
+#jira:PE


### PR DESCRIPTION
## Summary

[FCP-4780 - Update repos so that ProdEng receives Security tickets](https://wpengine.atlassian.net/browse/FCP-4780)

## Technical

* Adds @getflywheel/hosting-operations to CODEOWNERS
* Add Jira PE tag to the CODEOWNERS
* Update container labels to point to `pe-platform-prod-eng` ownership and `pe` Jira
